### PR TITLE
Use instance variables instead of class variables.

### DIFF
--- a/lib/inheritance_integer_type/extensions.rb
+++ b/lib/inheritance_integer_type/extensions.rb
@@ -21,7 +21,7 @@ module InheritanceIntegerType
     included do
       class << self
         def _inheritance_mapping
-          @_inheritance_mapping ||= (superclass == ActiveRecord::Base ? {} : superclass._inheritance_mapping)
+          @_inheritance_mapping ||= (superclass == ActiveRecord::Base ? {} : superclass._inheritance_mapping.dup)
         end
 
         def _inheritance_mapping=(val)

--- a/lib/inheritance_integer_type/extensions.rb
+++ b/lib/inheritance_integer_type/extensions.rb
@@ -16,26 +16,27 @@ module InheritanceIntegerType
         klass = sti_name_without_integer_types
         self._inheritance_mapping.key(klass) || klass
       end
-
-
     end
 
     included do
-      class_eval {
-        cattr_accessor :_inheritance_mapping
+      class << self
+        def _inheritance_mapping
+          @_inheritance_mapping ||= (superclass == ActiveRecord::Base ? {} : superclass._inheritance_mapping)
+        end
 
-        def self.merge_mapping!(mapping)
+        def _inheritance_mapping=(val)
+          @_inheritance_mapping = val
+        end
+
+        def merge_mapping!(mapping)
           conflicts = _inheritance_mapping.keys & mapping.keys
           raise ArgumentError.new("Duplicate mapping detected for keys: #{conflicts}") if conflicts.any?
 
           _inheritance_mapping.merge!(mapping)
         end
 
-        self._inheritance_mapping = {}
-        class << self
-          alias_method_chain :sti_name, :integer_types
-        end
-      }
+        alias_method_chain :sti_name, :integer_types
+      end
     end
 
   end


### PR DESCRIPTION
Consider the case where you have an abstract base class for your ActiveRecords:
```ruby
class BaseRecord < ActiveRecord::Base
  # some stuff...
end

class Foo < BaseRecord
  self._inheritance_mapping = {1: "FooBar", 2: "FooQuux"}
end

class FooBar < Foo; end
class FooQuux < Foo; end
```
This will presently explode. It'll start by loading BaseRecord, which creates the `@@_inheritance_mapping` variable, then loading Foo, setting the `_inheritance_mapping` on Foo in the process. But because `@@_inheritance_mapping` is a class variable, it's shared between _all children of BaseRecord_, leading to a situation where the contents of `_inheritance_mapping` are defined by load order and almost certainly wrong. Each child which gets loaded overwrites the previous `_inheritance_mapping` value for all BaseRecords.

This PR changes it to use an instance variable instead of a class variable. Each class initializes its mapping to `{}` if it's a direct child of ActiveRecord::Base, or to its parent's mapping otherwise. Since they all have separate mappings, they can't interfere with each other. (It does mean that it's harder to futz with the mappings after load time, but I'd argue you really, really shouldn't be doing that anyhow.)