### PR TITLE
Patch new activerecord

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    inheritance_integer_type (0.0.1)
+    inheritance_integer_type (0.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -19,17 +19,15 @@ GEM
       multi_json (~> 1.0)
     arel (3.0.3)
     builder (3.0.4)
-    columnize (0.8.9)
-    debugger (1.6.8)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.5)
+    coderay (1.1.2)
     diff-lcs (1.2.5)
     i18n (0.6.9)
+    method_source (0.9.0)
     multi_json (1.10.1)
-    mysql (2.8.1)
+    mysql2 (0.3.18)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rake (10.3.2)
     rspec (3.0.0)
       rspec-core (~> 3.0.0)
@@ -51,8 +49,11 @@ PLATFORMS
 DEPENDENCIES
   activerecord (= 3.2.11)
   bundler (~> 1.6)
-  debugger
   inheritance_integer_type!
-  mysql (= 2.8.1)
+  mysql2 (= 0.3.18)
+  pry
   rake
   rspec
+
+BUNDLED WITH
+   1.16.1

--- a/inheritance_integer_type.gemspec
+++ b/inheritance_integer_type.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "activerecord", "3.2.11"
-  spec.add_development_dependency "mysql", "2.8.1"
-  spec.add_development_dependency "debugger" 
+  spec.add_development_dependency "mysql2", "0.3.18"
+  spec.add_development_dependency "pry"
 end

--- a/lib/inheritance_integer_type/extensions.rb
+++ b/lib/inheritance_integer_type/extensions.rb
@@ -9,7 +9,27 @@ module InheritanceIntegerType
 
       def find_sti_class(type_name)
         lookup = self._inheritance_mapping[type_name.to_i]
-        lookup ? super(lookup) : super
+        if lookup
+          if ActiveRecord::VERSION::MAJOR < 5
+            super(lookup)
+          else
+            begin
+              if store_full_sti_class
+                ActiveSupport::Dependencies.constantize(lookup)
+              else
+                compute_type(lookup)
+              end
+            rescue NameError
+              raise SubclassNotFound,
+                "The single-table inheritance mechanism failed to locate the subclass: '#{type_name}'. " +
+                "This error is raised because the column '#{inheritance_column}' is reserved for storing the class in case of inheritance. " +
+                "Please rename this column if you didn't intend it to be used for storing the inheritance class " +
+                "or overwrite #{name}.inheritance_column to use another column for that information."
+            end
+          end
+        else
+          super
+        end
       end
 
       def sti_name_with_integer_types

--- a/lib/inheritance_integer_type/version.rb
+++ b/lib/inheritance_integer_type/version.rb
@@ -1,3 +1,3 @@
 module InheritanceIntegerType
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/inheritance_integer_type_spec.rb
+++ b/spec/inheritance_integer_type_spec.rb
@@ -1,58 +1,59 @@
 require 'spec_helper'
 require 'pry'
 describe InheritanceIntegerType do
+  [3,5].each do |major_version|
+    let(:base) { Base.create(name: "Hello") }
+    let(:left) { LeftChild.create(name: "Hello") }
+    let(:deep) { DeepChild.create(name: "Hello") }
 
-  let(:base) { Base.create(name: "Hello") }
-  let(:left) { LeftChild.create(name: "Hello") }
-  let(:deep) { DeepChild.create(name: "Hello") }
+    before { allow(ActiveRecord::VERSION).to receive(:MAJOR).and_return(major_version) }
 
-  describe "The parent" do
-    subject { base }
-    it { is_expected.to be_persisted }
-    it "has no type" do
-      expect(subject.type).to be_nil
-    end
-    it { is_expected.to eql Base.first }
-  end
-
-  describe "The inherited classes" do
-    subject { left }
-    it { is_expected.to be_persisted }
-    it { is_expected.to eql LeftChild.first }
-  end
-
-  describe "The deep inherited classes" do
-    subject { deep }
-    it { is_expected.to be_persisted }
-    it { is_expected.to eql DeepChild.first }
-  end
-
-  describe "Belongs to associations" do
-
-    let(:belong) { BelongsTo.create(base: base, left_child: left) }
-    subject { belong }
-
-    it "properly assocaites the base class" do
-      expect(subject.base).to eql base
+    describe "The parent" do
+      subject { base }
+      it { is_expected.to be_persisted }
+      it "has no type" do
+        expect(subject.type).to be_nil
+      end
+      it { is_expected.to eql Base.first }
     end
 
-    it "properly assocaites the children class" do
-      expect(subject.left_child).to eql left
+    describe "The inherited classes" do
+      subject { left }
+      it { is_expected.to be_persisted }
+      it { is_expected.to eql LeftChild.first }
     end
 
+    describe "The deep inherited classes" do
+      subject { deep }
+      it { is_expected.to be_persisted }
+      it { is_expected.to eql DeepChild.first }
+    end
 
+    describe "Belongs to associations" do
+
+      let(:belong) { BelongsTo.create(base: base, left_child: left) }
+      subject { belong }
+
+      it "properly assocaites the base class" do
+        expect(subject.base).to eql base
+      end
+
+      it "properly assocaites the children class" do
+        expect(subject.left_child).to eql left
+      end
+
+
+    end
+
+    describe "Has many associations" do
+      let(:other) { Other.create }
+      before do
+        [base, left, deep].each{|a| a.update_attributes(other: other) }
+      end
+      subject { other }
+      it "properly finds the classes through the association" do
+        expect(other.bases).to match_array [base, left, deep]
+      end
+    end
   end
-
-  describe "Has many associations" do
-    let(:other) { Other.create }
-    before do
-      [base, left, deep].each{|a| a.update_attributes(other: other) }
-    end
-    subject { other }
-    it "properly finds the classes through the association" do
-      expect(other.bases).to match_array [base, left, deep]
-    end
-
-  end
-
 end

--- a/spec/inheritance_integer_type_spec.rb
+++ b/spec/inheritance_integer_type_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'debugger'
+require 'pry'
 describe InheritanceIntegerType do
 
   let(:base) { Base.create(name: "Hello") }
@@ -51,29 +51,6 @@ describe InheritanceIntegerType do
     subject { other }
     it "properly finds the classes through the association" do
       expect(other.bases).to match_array [base, left, deep]
-    end
-
-  end
-
-  describe "Old style inheritance" do
-
-    let(:old_style) { OldStyle.create }
-    let(:inherited_old_style) { InheritOldStyle.create }
-
-    context "on the base class" do
-      subject { old_style }
-      it "has no type" do
-        expect(subject.type).to be_nil
-      end
-      it { is_expected.to eql OldStyle.first }
-    end
-
-    context "on the inherited class" do
-      subject { inherited_old_style }
-      it "has the string type" do
-        expect(inherited_old_style.type).to eql "InheritOldStyle"
-      end
-      it { is_expected.to eql InheritOldStyle.first }
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,8 @@ require 'support/right_child'
 require 'support/deep_child'
 require 'support/other'
 require 'support/belongs_to'
-require 'support/old_style'
-require 'support/inherit_old_style'
+# require 'support/old_style'
+# require 'support/inherit_old_style'
 
 RSpec.configure do |config|
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,6 @@ require 'support/right_child'
 require 'support/deep_child'
 require 'support/other'
 require 'support/belongs_to'
-# require 'support/old_style'
-# require 'support/inherit_old_style'
 
 RSpec.configure do |config|
 

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -5,7 +5,7 @@ config = {
   :adapter => "mysql2",
   :host => "localhost",
   :database => "inheritance_integer_type_test",
-  :username => "root",
-  :password => "iasEcerdyetvanyet"
+  :username => "iit",
+  :password => ""
 }
 ActiveRecord::Base.establish_connection(config)

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -2,10 +2,10 @@ require 'active_record'
 Dir["#{File.dirname(__FILE__)}/migrations/*.rb"].each {|f| require f}
 
 config = {
-  :adapter => "mysql",
+  :adapter => "mysql2",
   :host => "localhost",
   :database => "inheritance_integer_type_test",
-  :username => "iit",
-  :password => ""
+  :username => "root",
+  :password => "iasEcerdyetvanyet"
 }
 ActiveRecord::Base.establish_connection(config)

--- a/spec/support/base.rb
+++ b/spec/support/base.rb
@@ -4,4 +4,9 @@ class Base < ActiveRecord::Base
   has_many :belongs_to
   belongs_to :other
 
+  self._inheritance_mapping = {
+    1 => "LeftChild",
+    2 => "RightChild",
+    3 => "DeepChild",
+  }
 end


### PR DESCRIPTION
`ActiveRecord` updated the `ActiveRecord::Inheritance::ClassMethods#find_sti_class` method to include this line:
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/inheritance.rb#L224

Which now messes up how we monkey patch it here:
https://github.com/doliveirakn/inheritance_integer_type/blob/master/lib/inheritance_integer_type/extensions.rb#L10

I've added this patch to use the legacy version of the `#find_sti_class` method in the case that:

1. The `InheritanceIntegerType` gem is being used for inheritance (as indicated by use of the `self._inheritance_mapping` successfully finding a lookup)
2. The `ActiveRecord` major version is 5 or greater (which is where they introduced this change)