### PR TITLE
Deprecate alias_method_chain and use in-memory sqlite3 for specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,6 @@ GEM
       concurrent-ruby (~> 1.0)
     method_source (0.9.0)
     minitest (5.11.3)
-    mysql2 (0.3.18)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -42,6 +41,7 @@ GEM
     rspec-mocks (3.0.1)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.0)
+    sqlite3 (1.3.13)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -53,10 +53,10 @@ DEPENDENCIES
   activerecord
   bundler (~> 1.6)
   inheritance_integer_type!
-  mysql2 (= 0.3.18)
   pry
   rake
   rspec
+  sqlite3 (~> 1.3.6)
 
 BUNDLED WITH
-   1.16.1
+   1.16.6

--- a/inheritance_integer_type.gemspec
+++ b/inheritance_integer_type.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "activerecord"
-  spec.add_development_dependency "mysql2", "0.3.18"
+  spec.add_development_dependency "sqlite3", "~> 1.3.6"
   spec.add_development_dependency "pry"
 end

--- a/lib/inheritance_integer_type.rb
+++ b/lib/inheritance_integer_type.rb
@@ -2,10 +2,5 @@ require "inheritance_integer_type/version"
 require "inheritance_integer_type/extensions"
 
 class ActiveRecord::Base
-
-  def self.inherited(child_class)
-    child_class.include InheritanceIntegerType::Extensions
-    super
-  end
-
+  singleton_class.prepend(InheritanceIntegerType::Extensions)
 end

--- a/lib/inheritance_integer_type/extensions.rb
+++ b/lib/inheritance_integer_type/extensions.rb
@@ -1,63 +1,53 @@
 module InheritanceIntegerType
   module Extensions
-    extend ActiveSupport::Concern
-    module ClassMethods
+    def sti_name
+      klass = super
+      self._inheritance_mapping.key(klass) || klass
+    end
 
-      def integer_inheritance=(val)
-        self._inheritance_mapping[val] = sti_name_without_integer_types
-      end
-
-      def find_sti_class(type_name)
-        lookup = self._inheritance_mapping[type_name.to_i]
-        if lookup
-          if ActiveRecord::VERSION::MAJOR < 5
-            super(lookup)
-          else
-            begin
-              if store_full_sti_class
-                ActiveSupport::Dependencies.constantize(lookup)
-              else
-                compute_type(lookup)
-              end
-            rescue NameError
-              raise SubclassNotFound,
-                "The single-table inheritance mechanism failed to locate the subclass: '#{type_name}'. " +
-                "This error is raised because the column '#{inheritance_column}' is reserved for storing the class in case of inheritance. " +
-                "Please rename this column if you didn't intend it to be used for storing the inheritance class " +
-                "or overwrite #{name}.inheritance_column to use another column for that information."
-            end
-          end
+    def find_sti_class(type_name)
+      lookup = self._inheritance_mapping[type_name.to_i]
+      if lookup
+        if ActiveRecord::VERSION::MAJOR < 5
+          super(lookup)
         else
-          super
+          begin
+            if store_full_sti_class
+              ActiveSupport::Dependencies.constantize(lookup)
+            else
+              compute_type(lookup)
+            end
+          rescue NameError
+            raise SubclassNotFound,
+              "The single-table inheritance mechanism failed to locate the subclass: '#{type_name}'. " +
+              "This error is raised because the column '#{inheritance_column}' is reserved for storing the class in case of inheritance. " +
+              "Please rename this column if you didn't intend it to be used for storing the inheritance class " +
+              "or overwrite #{name}.inheritance_column to use another column for that information."
+          end
         end
-      end
-
-      def sti_name_with_integer_types
-        klass = sti_name_without_integer_types
-        self._inheritance_mapping.key(klass) || klass
-      end
-    end
-
-    included do
-      class << self
-        def _inheritance_mapping
-          @_inheritance_mapping ||= (superclass == ActiveRecord::Base ? {} : superclass._inheritance_mapping.dup)
-        end
-
-        def _inheritance_mapping=(val)
-          @_inheritance_mapping = val
-        end
-
-        def merge_mapping!(mapping)
-          conflicts = _inheritance_mapping.keys & mapping.keys
-          raise ArgumentError.new("Duplicate mapping detected for keys: #{conflicts}") if conflicts.any?
-
-          _inheritance_mapping.merge!(mapping)
-        end
-
-        alias_method_chain :sti_name, :integer_types
+      else
+        super
       end
     end
 
+    def integer_inheritance=(val)
+      self._inheritance_mapping[val] = method(:sti_name).super_method.call
+    end
+
+    def _inheritance_mapping
+      @_inheritance_mapping ||= (superclass == ActiveRecord::Base ? {} : superclass._inheritance_mapping.dup)
+    end
+
+    def _inheritance_mapping=(val)
+      @_inheritance_mapping = val
+    end
+
+    def merge_mapping!(mapping)
+      conflicts = _inheritance_mapping.keys & mapping.keys
+      raise ArgumentError.new("Duplicate mapping detected for keys: #{conflicts}") if conflicts.any?
+
+      _inheritance_mapping.merge!(mapping)
+    end
   end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,9 +8,8 @@ require 'support/other'
 require 'support/belongs_to'
 
 RSpec.configure do |config|
-
   config.before(:suite) do
-    ActiveRecord::Migrator.up "#{File.dirname(__FILE__)}/support/migrations"
+    ActiveRecord::MigrationContext.new("#{File.dirname(__FILE__)}/support/migrations").migrate
   end
 
   # No need to return the run the down migration after the test
@@ -18,7 +17,6 @@ RSpec.configure do |config|
   # config.after(:suite) do
   #   ActiveRecord::Migrator.down "#{File.dirname(__FILE__)}/support/migrations"
   # end
-
 
   config.around do |example|
     ActiveRecord::Base.transaction do

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -2,10 +2,7 @@ require 'active_record'
 Dir["#{File.dirname(__FILE__)}/migrations/*.rb"].each {|f| require f}
 
 config = {
-  :adapter => "mysql2",
-  :host => "localhost",
-  :database => "inheritance_integer_type_test",
-  :username => "iit",
-  :password => ""
+  :adapter => "sqlite3",
+  :database => ":memory:",
 }
 ActiveRecord::Base.establish_connection(config)

--- a/spec/support/base.rb
+++ b/spec/support/base.rb
@@ -1,6 +1,4 @@
 class Base < ActiveRecord::Base
-  include InheritanceIntegerType::Extensions
-  
   has_many :belongs_to
   belongs_to :other
 

--- a/spec/support/migrations/1_create_base_table.rb
+++ b/spec/support/migrations/1_create_base_table.rb
@@ -1,4 +1,4 @@
-class CreateBaseTable < ActiveRecord::Migration
+class CreateBaseTable < ActiveRecord::Migration[5.2]
 
   def change
     create_table :bases do |t|

--- a/spec/support/migrations/2_create_belong_to_table.rb
+++ b/spec/support/migrations/2_create_belong_to_table.rb
@@ -1,4 +1,4 @@
-class CreateBelongToTable < ActiveRecord::Migration
+class CreateBelongToTable < ActiveRecord::Migration[5.2]
 
   def change
     create_table :belongs_tos do |t|

--- a/spec/support/migrations/3_create_other_table.rb
+++ b/spec/support/migrations/3_create_other_table.rb
@@ -1,4 +1,4 @@
-class CreateOtherTable < ActiveRecord::Migration
+class CreateOtherTable < ActiveRecord::Migration[5.2]
 
   def change
     create_table :others do |t|


### PR DESCRIPTION
The method `alias_method_chain` no longer exists in Rails 5.1+. The patch uses `prepend` to replace `alias_method_chain`, and simplifies the loading of specs with in-memory db.