### PR TITLE
Convert owner to owners in overlord.yml

### DIFF
--- a/overlord.yml
+++ b/overlord.yml
@@ -1,3 +1,4 @@
 tier: 3
-owner: backend-infrastructure
+owners:
+  - backend-infrastructure
 classification: library


### PR DESCRIPTION
## Summary
- Converts `owner: backend-infrastructure` to `owners:` (plural YAML sequence format)
- `backend-infrastructure` is no longer in the Clio GitHub org - a new owner should be assigned

## Context
The `owner` field (singular) is deprecated in overlord.yml. All repos should use `owners` (plural).

Generated by Overlord owner-to-owners migration.